### PR TITLE
Protect collaborators routes

### DIFF
--- a/src/main/java/br/com/chronos/core/modules/auth/domain/entities/Account.java
+++ b/src/main/java/br/com/chronos/core/modules/auth/domain/entities/Account.java
@@ -4,6 +4,7 @@ import br.com.chronos.core.modules.global.domain.abstracts.Entity;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Logical;
 import br.com.chronos.core.modules.auth.domain.dtos.AccountDto;
+import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.records.CollaboratorRole;
 import br.com.chronos.core.modules.collaboration.domain.records.CollaboratorSector;
 import br.com.chronos.core.modules.collaboration.domain.records.Password;
@@ -24,6 +25,7 @@ public final class Account extends Entity {
     isActive = (dto.isActive != null) ? Logical.create(dto.isActive) : Logical.create(true);
 
   }
+
   public Email getEmail() {
     return email;
   }
@@ -58,6 +60,17 @@ public final class Account extends Entity {
 
   public CollaboratorSector getSector() {
     return sector;
+  }
+
+  public Logical isFromSameSector(Collaborator otherAccount) {
+    if (otherAccount == null) {
+      return Logical.createAsFalse();
+    }
+    if (this.role.isAdmin().value()) {
+      return Logical.createAsTrue();
+    }
+
+    return Logical.create(this.getSector().value().equals(otherAccount.getSector().value()));
   }
 
   public AccountDto getDto() {

--- a/src/main/java/br/com/chronos/core/modules/auth/domain/exceptions/AccountNotFoundException.java
+++ b/src/main/java/br/com/chronos/core/modules/auth/domain/exceptions/AccountNotFoundException.java
@@ -4,6 +4,6 @@ import br.com.chronos.core.modules.global.domain.exceptions.NotFoundException;
 
 public class AccountNotFoundException extends NotFoundException{
   public AccountNotFoundException(){
-    super("Conta nao encontrado");
+    super("Conta nao encontrada");
   }
 }

--- a/src/main/java/br/com/chronos/core/modules/auth/domain/exceptions/DisabledAccountException.java
+++ b/src/main/java/br/com/chronos/core/modules/auth/domain/exceptions/DisabledAccountException.java
@@ -1,0 +1,9 @@
+package br.com.chronos.core.modules.auth.domain.exceptions;
+
+import br.com.chronos.core.modules.global.domain.exceptions.AppException;
+
+public class DisabledAccountException extends AppException {
+  public DisabledAccountException(){
+    super("Erro de autenticacao","Conta desativada");
+  }
+}

--- a/src/main/java/br/com/chronos/core/modules/auth/domain/exceptions/NotAuthorizedException.java
+++ b/src/main/java/br/com/chronos/core/modules/auth/domain/exceptions/NotAuthorizedException.java
@@ -1,0 +1,9 @@
+package br.com.chronos.core.modules.auth.domain.exceptions;
+
+import br.com.chronos.core.modules.global.domain.exceptions.AppException;
+
+public class NotAuthorizedException extends AppException {
+  public NotAuthorizedException(){
+    super("Erro de autenticacao","Permissao invalida");
+  }
+}

--- a/src/main/java/br/com/chronos/core/modules/auth/use_cases/LoginUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/auth/use_cases/LoginUseCase.java
@@ -1,6 +1,5 @@
 package br.com.chronos.core.modules.auth.use_cases;
 
-import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthenticatedException;
 import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 
 public class LoginUseCase {
@@ -11,11 +10,7 @@ public class LoginUseCase {
   }
 
   public String execute(String email, String password) {
-    try {
-      var jwt = authenticationProvider.login(email, password);
-      return jwt;
-    } catch (Exception e) {
-      throw new NotAuthenticatedException();
-    }
+    var jwt = authenticationProvider.login(email, password);
+    return jwt;
   }
 }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/domain/exceptions/ExistingEmailException.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/domain/exceptions/ExistingEmailException.java
@@ -1,5 +1,6 @@
 package br.com.chronos.core.modules.collaboration.domain.exceptions;
 
+import br.com.chronos.core.modules.global.domain.exceptions.ConflictException;
 
 public class ExistingEmailException extends ConflictException {
   public ExistingEmailException(){

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/CreateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/CreateCollaboratorUseCase.java
@@ -5,6 +5,7 @@ import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 import br.com.chronos.core.modules.auth.domain.entities.Account;
 import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthenticatedException;
+import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthorizedException;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.exceptions.ExistingCpfException;
@@ -25,9 +26,8 @@ public class CreateCollaboratorUseCase {
     var collaboratorDto = authenticationProvider.register(dto);
     var collaborator = new Collaborator(collaboratorDto);
     if (!collaboratorCreator.isFromSameSector(collaborator).value()) {
-      throw new NotAuthenticatedException();
+      throw new NotAuthorizedException();
     }
-
     repository.add(collaborator);
     return collaborator.getDto();
   }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/CreateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/CreateCollaboratorUseCase.java
@@ -3,6 +3,8 @@ package br.com.chronos.core.modules.collaboration.use_cases;
 import br.com.chronos.core.modules.global.domain.records.Cpf;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
+import br.com.chronos.core.modules.auth.domain.entities.Account;
+import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthenticatedException;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.exceptions.ExistingCpfException;
@@ -13,15 +15,19 @@ public class CreateCollaboratorUseCase {
   private final CollaboratorsRepository repository;
   private final AuthenticationProvider authenticationProvider;
 
-  public CreateCollaboratorUseCase(CollaboratorsRepository repository,AuthenticationProvider authenticationProvider) {
+  public CreateCollaboratorUseCase(CollaboratorsRepository repository, AuthenticationProvider authenticationProvider) {
     this.repository = repository;
     this.authenticationProvider = authenticationProvider;
   }
 
-  public CollaboratorDto execute(CollaboratorDto dto) {
+  public CollaboratorDto execute(CollaboratorDto dto, Account collaboratorCreator) {
     validateUniqueEmailAndCpf(dto);
     var collaboratorDto = authenticationProvider.register(dto);
     var collaborator = new Collaborator(collaboratorDto);
+    if (!collaboratorCreator.isFromSameSector(collaborator).value()) {
+      throw new NotAuthenticatedException();
+    }
+
     repository.add(collaborator);
     return collaborator.getDto();
   }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/DisableCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/DisableCollaboratorUseCase.java
@@ -1,5 +1,7 @@
 package br.com.chronos.core.modules.collaboration.use_cases;
 
+import br.com.chronos.core.modules.auth.domain.entities.Account;
+import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthenticatedException;
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.exceptions.CollaboratorNotFoundException;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
@@ -12,8 +14,12 @@ public class DisableCollaboratorUseCase {
     this.repository = repository;
   }
 
-  public void execute(String collaboratorId) {
+  public void execute(String collaboratorId,Account collaboratorDeactivator) {
     var collaborator = findCollaborator(Id.create(collaboratorId));
+    if (!collaboratorDeactivator.isFromSameSector(collaborator).value()) {
+      throw new NotAuthenticatedException();
+      
+    }
     collaborator.disable();
     repository.disable(collaborator);
   }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/EnableCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/EnableCollaboratorUseCase.java
@@ -1,5 +1,7 @@
 package br.com.chronos.core.modules.collaboration.use_cases;
 
+import br.com.chronos.core.modules.auth.domain.entities.Account;
+import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthenticatedException;
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.exceptions.CollaboratorNotFoundException;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
@@ -12,8 +14,11 @@ public class EnableCollaboratorUseCase {
     this.repository = repository;
   }
 
-  public void execute(String collaboratorId) {
+  public void execute(String collaboratorId, Account collaboratorActivator) {
     var collaborator = findCollaborator(Id.create(collaboratorId));
+    if (!collaboratorActivator.isFromSameSector(collaborator).value()) {
+      throw new NotAuthenticatedException();
+    }
     collaborator.enable();
     repository.enable(collaborator);
   }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/UpdateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/UpdateCollaboratorUseCase.java
@@ -29,6 +29,7 @@ public class UpdateCollaboratorUseCase {
     }
     validateUniqueEmailAndCpf(dto, Id.create(collaboratorId));
     collaborator.update(dto);
+
     repository.update(collaborator);
     return collaborator.getDto();
   }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/UpdateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/UpdateCollaboratorUseCase.java
@@ -1,5 +1,7 @@
 package br.com.chronos.core.modules.collaboration.use_cases;
 
+import br.com.chronos.core.modules.auth.domain.entities.Account;
+import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthorizedException;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.exceptions.CollaboratorNotFoundException;
@@ -17,8 +19,14 @@ public class UpdateCollaboratorUseCase {
     this.repository = repository;
   }
 
-  public CollaboratorDto execute(String collaboratorId, CollaboratorDto dto) {
+  public CollaboratorDto execute(String collaboratorId, CollaboratorDto dto, Account responsible) {
     var collaborator = findCollaborator(Id.create(collaboratorId));
+    if (!responsible.isFromSameSector(collaborator).value()) {
+      throw new NotAuthorizedException();
+    }
+    if (dto.sector != null && !responsible.getRole().isAdmin().value()) {
+      throw new NotAuthorizedException();
+    }
     validateUniqueEmailAndCpf(dto, Id.create(collaboratorId));
     collaborator.update(dto);
     repository.update(collaborator);

--- a/src/main/java/br/com/chronos/core/modules/global/interfaces/providers/AuthenticationProvider.java
+++ b/src/main/java/br/com/chronos/core/modules/global/interfaces/providers/AuthenticationProvider.java
@@ -1,11 +1,14 @@
 package br.com.chronos.core.modules.global.interfaces.providers;
 
+import br.com.chronos.core.modules.auth.domain.entities.Account;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 
 public interface AuthenticationProvider {
   String login(String email, String password);
 
   CollaboratorDto register(CollaboratorDto dto);
+
+  Account getAuthenticatedUser();
 
   void logout();
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/ApiExceptionHandler.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/ApiExceptionHandler.java
@@ -2,10 +2,13 @@ package br.com.chronos.server.api.controllers;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import br.com.chronos.core.modules.auth.domain.exceptions.DisabledAccountException;
 import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthenticatedException;
+import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthorizedException;
 import br.com.chronos.core.modules.global.domain.exceptions.AppException;
 import br.com.chronos.core.modules.global.domain.exceptions.ConflictException;
 import br.com.chronos.core.modules.global.domain.exceptions.NotFoundException;
@@ -21,35 +24,53 @@ public class ApiExceptionHandler {
     private String title;
     private String message;
   }
-  
+
   @ExceptionHandler(NotFoundException.class)
-  private ResponseEntity<ExceptionMessage> handleNotFoundException(NotFoundException exception){
-    var message = new ExceptionMessage(exception.getTitle(),exception.getMessage());
+  private ResponseEntity<ExceptionMessage> handleNotFoundException(NotFoundException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(message);
   }
-  @ExceptionHandler(RuntimeException.class)
-  private ResponseEntity<ExceptionMessage> handleRunTimeException(RuntimeException exception){
-    var message = new ExceptionMessage("Run time exception",exception.getMessage());
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(message);
-  }
+
+
   @ExceptionHandler(ValidationException.class)
-  private ResponseEntity<ExceptionMessage> handleValidationException(ValidationException exception){
-    var message = new ExceptionMessage(exception.getTitle(),exception.getMessage());
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(message);
+  private ResponseEntity<ExceptionMessage> handleValidationException(ValidationException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
   }
+
   @ExceptionHandler(AppException.class)
-  private ResponseEntity<ExceptionMessage> handleAppException(AppException exception){
-    var message = new ExceptionMessage(exception.getTitle(),exception.getMessage());
+  private ResponseEntity<ExceptionMessage> handleAppException(AppException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(message);
   }
+
   @ExceptionHandler(NotAuthenticatedException.class)
-  private ResponseEntity<ExceptionMessage> handleNotAuthenticatedException(NotAuthenticatedException exception){
-    var message = new ExceptionMessage(exception.getTitle(),exception.getMessage());
+  private ResponseEntity<ExceptionMessage> handleNotAuthenticatedException(NotAuthenticatedException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(message);
   }
+
   @ExceptionHandler(ConflictException.class)
-  private ResponseEntity<ExceptionMessage> handleConflictException(ConflictException exception){
-    var message = new ExceptionMessage(exception.getTitle(),exception.getMessage());
+  private ResponseEntity<ExceptionMessage> handleConflictException(ConflictException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(message);
+  }
+
+  @ExceptionHandler(NotAuthorizedException.class)
+  private ResponseEntity<ExceptionMessage> handleNotAuthorizedException(NotAuthorizedException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(message);
+  }
+
+  @ExceptionHandler(DisabledException.class)
+  private ResponseEntity<ExceptionMessage> handleDisabledAccountException(DisabledAccountException exception) {
+    var message = new ExceptionMessage(exception.getTitle(), exception.getMessage());
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(message);
+  }
+
+  @ExceptionHandler(RuntimeException.class)
+  private ResponseEntity<ExceptionMessage> handleRunTimeException(RuntimeException exception) {
+    var message = new ExceptionMessage("Run time exception", exception.getMessage());
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(message);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaborators/CreateCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaborators/CreateCollaboratorController.java
@@ -23,7 +23,8 @@ public class CreateCollaboratorController {
   @PostMapping
   public ResponseEntity<CollaboratorDto> handle(@RequestBody CollaboratorDto body) {
     var useCase = new CreateCollaboratorUseCase(repository,authenticationProvider);
-    var collaboratorDto = useCase.execute(body);
+    var responsible = authenticationProvider.getAuthenticatedUser();
+    var collaboratorDto = useCase.execute(body,responsible);
     return ResponseEntity.status(HttpStatus.OK).body(collaboratorDto);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaborators/DisableCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaborators/DisableCollaboratorController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.modules.collaboration.use_cases.DisableCollaboratorUseCase;
+import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 
 @CollaboratorsController
 public class DisableCollaboratorController {
@@ -16,10 +17,14 @@ public class DisableCollaboratorController {
   @Autowired
   private CollaboratorsRepository repository;
 
+  @Autowired
+  private AuthenticationProvider authenticationProvider;
+
   @DeleteMapping("/disable/{id}")
   public ResponseEntity<CollaboratorDto> handle(@PathVariable("id") String collaboratorId) {
     var useCase = new DisableCollaboratorUseCase(repository);
-    useCase.execute(collaboratorId);
+    var responsible = authenticationProvider.getAuthenticatedUser();
+    useCase.execute(collaboratorId,responsible);
     return ResponseEntity.status(HttpStatus.OK).body(null);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaborators/EnableCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaborators/EnableCollaboratorController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.modules.collaboration.use_cases.EnableCollaboratorUseCase;
+import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 
 @CollaboratorsController
 public class EnableCollaboratorController {
@@ -16,10 +17,14 @@ public class EnableCollaboratorController {
   @Autowired
   private CollaboratorsRepository repository;
 
+  @Autowired
+  private AuthenticationProvider authenticationProvider;
+
   @PostMapping("/enable/{id}")
   public ResponseEntity<CollaboratorDto> handle(@PathVariable("id") String collaboratorId) {
     var useCase = new EnableCollaboratorUseCase(repository);
-    useCase.execute(collaboratorId);
+    var responsible = authenticationProvider.getAuthenticatedUser();
+    useCase.execute(collaboratorId,responsible);
     return ResponseEntity.status(HttpStatus.OK).body(null);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaborators/UpdateCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaborators/UpdateCollaboratorController.java
@@ -10,17 +10,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.modules.collaboration.use_cases.UpdateCollaboratorUseCase;
+import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 
 @CollaboratorsController
 public class UpdateCollaboratorController {
 
   @Autowired
   private CollaboratorsRepository repository;
+  @Autowired
+  private AuthenticationProvider authenticationProvider;
 
   @PutMapping("/{id}")
   public ResponseEntity<CollaboratorDto> handle(@PathVariable("id") String collaboratorId,@RequestBody CollaboratorDto body) {
     var useCase = new UpdateCollaboratorUseCase(repository);
-    var response = useCase.execute(collaboratorId, body);
+    var responsible = authenticationProvider.getAuthenticatedUser();
+    var response = useCase.execute(collaboratorId, body,responsible);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/work_schedule/workday_logs/ListCollaboratorWorkdayLogsController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/work_schedule/workday_logs/ListCollaboratorWorkdayLogsController.java
@@ -1,7 +1,6 @@
 package br.com.chronos.server.api.controllers.work_schedule.workday_logs;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/br/com/chronos/server/infra/cors/CorsConfig.java
+++ b/src/main/java/br/com/chronos/server/infra/cors/CorsConfig.java
@@ -1,0 +1,30 @@
+package br.com.chronos.server.infra.cors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import br.com.chronos.core.modules.global.interfaces.providers.EnvProvider;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+  @Autowired
+  private EnvProvider dotenvProvider;
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    String allowedOrigin = dotenvProvider.get("WEB_APP_URL");
+    if (allowedOrigin == null || allowedOrigin.isEmpty()) {
+      throw new IllegalStateException("Missing required environment for variable for Web App Url ");
+    }
+
+    registry.addMapping("/**")
+        .allowedOrigins(allowedOrigin)
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+        .allowedHeaders("*")
+        .allowCredentials(true);
+  }
+
+}

--- a/src/main/java/br/com/chronos/server/infra/security/SecurityConfiguration.java
+++ b/src/main/java/br/com/chronos/server/infra/security/SecurityConfiguration.java
@@ -1,6 +1,4 @@
-package br.com.chronos.server.security;
-
-import java.util.List;
+package br.com.chronos.server.infra.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -15,11 +13,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import br.com.chronos.core.modules.global.interfaces.providers.EnvProvider;
 
 @Configuration
 @EnableWebSecurity
@@ -28,14 +21,11 @@ public class SecurityConfiguration {
   @Autowired
   private SecurityJwtFilter securityJwtFilter;
 
-  @Autowired
-  private EnvProvider dotenvProvider;
 
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
     return httpSecurity
         .csrf(crsf -> crsf.disable())
-        .cors(cors -> cors.configurationSource(configurationSource()))
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
@@ -44,24 +34,6 @@ public class SecurityConfiguration {
         .addFilterBefore(securityJwtFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
-
-  @Bean
-  CorsConfigurationSource configurationSource() {
-    var source = new UrlBasedCorsConfigurationSource();
-    CorsConfiguration defaultConfig = new CorsConfiguration();
-
-    String allowedOrigin = dotenvProvider.get("WEB_APP_URL");
-    if (allowedOrigin == null || allowedOrigin.isEmpty()) {
-      throw new IllegalStateException("Missing required environment for variable for Web App Url ");
-    }
-
-    defaultConfig.setAllowedOrigins(List.of(allowedOrigin));
-    defaultConfig.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
-    defaultConfig.setAllowedHeaders(List.of("*"));
-    source.registerCorsConfiguration("/**", defaultConfig);
-    return source;
-  }
-
   @Bean
   AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
     return configuration.getAuthenticationManager();

--- a/src/main/java/br/com/chronos/server/infra/security/SecurityJwtFilter.java
+++ b/src/main/java/br/com/chronos/server/infra/security/SecurityJwtFilter.java
@@ -1,4 +1,4 @@
-package br.com.chronos.server.security;
+package br.com.chronos.server.infra.security;
 
 import java.io.IOException;
 

--- a/src/main/java/br/com/chronos/server/infra/security/SecurityUser.java
+++ b/src/main/java/br/com/chronos/server/infra/security/SecurityUser.java
@@ -1,4 +1,4 @@
-package br.com.chronos.server.security;
+package br.com.chronos.server.infra.security;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/br/com/chronos/server/infra/security/SecurityUserService.java
+++ b/src/main/java/br/com/chronos/server/infra/security/SecurityUserService.java
@@ -1,4 +1,4 @@
-package br.com.chronos.server.security;
+package br.com.chronos.server.infra.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;


### PR DESCRIPTION
###  Ajustando Proteção de Rotas de Colaboradores  
**Branch:** `protect-collaborators-routes`  

#### 📝 Changelog  
- Criadas duas novas exceções: `NotAuthorizedException` e `DisableAccountException`.  
- Implementada validação nas operações de **criação, desativação, ativação e edição de colaboradores** com a seguinte lógica:  
  - **Admin:** possui acesso total às operações.  
  - **Gestor:**  
    - **Não pode** modificar colaboradores de outro setor.  
    - **Não pode** alterar o setor de um colaborador, mesmo dentro do próprio setor.  

#### ✅ Como Testar  
Utilize **Postman**, **cURL** ou **Hoppscotch** para realizar as requisições.  

1. **Testando com um Gestor de RH:**  
   - Tente alterar o nome de um colaborador do setor **Production** → **Deve retornar erro**.  
   - Tente alterar o nome de um colaborador do setor **RH** → **Deve ser permitido**.  
   - Tente alterar o setor de um colaborador do setor **RH** → **Deve retornar erro**.  

2. **Testando com um Admin:**  
   - Todas as operações devem ser **liberadas**.  
