### PR TITLE
Collaboration route protection

### DIFF
--- a/src/main/java/br/com/chronos/core/modules/collaboration/domain/entities/Collaborator.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/domain/entities/Collaborator.java
@@ -8,6 +8,7 @@ import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Logical;
 import br.com.chronos.core.modules.global.domain.records.Role;
 import br.com.chronos.core.modules.global.domain.records.Text;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 
 public final class Collaborator extends Entity {
   private Text name;
@@ -27,7 +28,7 @@ public final class Collaborator extends Entity {
     isActive = (dto.isActive != null) ? Logical.create(dto.isActive) : Logical.create(true);
   }
 
-  public Logical isFromSameSector(CollaborationSector sector, Role role) {
+  public Logical isFromSameSector(Sector sector, Role role) {
     if (sector == null) {
       return Logical.createAsFalse();
     }
@@ -38,7 +39,7 @@ public final class Collaborator extends Entity {
       return Logical.createAsTrue();
     }
 
-    return Logical.create(this.getSector().value().equals(sector.value()));
+    return Logical.create(this.getSector().value().equals(sector));
   }
 
   public Text getName() {

--- a/src/main/java/br/com/chronos/core/modules/collaboration/interfaces/repositories/CollaboratorsRepository.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/interfaces/repositories/CollaboratorsRepository.java
@@ -4,17 +4,18 @@ import java.util.Optional;
 
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.global.domain.records.Array;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 import br.com.chronos.core.modules.global.domain.records.Cpf;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Id;
+import br.com.chronos.core.modules.global.domain.records.Logical;
 import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.PlusInteger;
 import br.com.chronos.core.modules.global.domain.records.Role;
-import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 import kotlin.Pair;
 
 public interface CollaboratorsRepository {
-  Pair<Array<Collaborator>, PlusInteger> findMany(PageNumber page,Role.RoleName role,Sector sector);
+  Pair<Array<Collaborator>, PlusInteger> findMany(PageNumber page,Role.RoleName role,Sector sector,Logical isActive);
 
   Optional<Collaborator> findCollaboratorById(Id id);
 

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/CreateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/CreateCollaboratorUseCase.java
@@ -15,6 +15,7 @@ import br.com.chronos.core.modules.global.domain.records.Cpf;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Role;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 
 public class CreateCollaboratorUseCase {
@@ -33,7 +34,7 @@ public class CreateCollaboratorUseCase {
   }
 
   public CollaboratorDto execute(CollaboratorDto dto, Id workScheduleId, Password password,
-      CollaborationSector responsibleSector, Role responsibleRole) {
+       Sector   responsibleSector  , Role responsibleRole  ){
 
     validateUniqueEmailAndCpf(dto);
     var collaborator = new Collaborator(dto);

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/DisableCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/DisableCollaboratorUseCase.java
@@ -6,6 +6,8 @@ import br.com.chronos.core.modules.collaboration.domain.exceptions.CollaboratorN
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Id;
+import br.com.chronos.core.modules.global.domain.records.Role;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 
 public class DisableCollaboratorUseCase {
   private final CollaboratorsRepository repository;
@@ -14,10 +16,9 @@ public class DisableCollaboratorUseCase {
     this.repository = repository;
   }
 
-  public void execute(String collaboratorId, Email collaboratorDeactivatorEmail) {
-    var collaboratorDeactivator = this.repository.findByEmail(collaboratorDeactivatorEmail);
+  public void execute(String collaboratorId, Sector responsibleSector, Role responsibleRole) {
     var collaborator = findCollaborator(Id.create(collaboratorId));
-    if (!collaboratorDeactivator.get().isFromSameSector(collaborator).value()) {
+    if (collaborator.isFromSameSector(responsibleSector, responsibleRole).isFalse()) {
       throw new NotAuthorizedException();
 
     }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/DisableCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/DisableCollaboratorUseCase.java
@@ -4,10 +4,9 @@ import br.com.chronos.core.modules.auth.domain.exceptions.NotAuthorizedException
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.core.modules.collaboration.domain.exceptions.CollaboratorNotFoundException;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
-import br.com.chronos.core.modules.global.domain.records.Email;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Role;
-import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 
 public class DisableCollaboratorUseCase {
   private final CollaboratorsRepository repository;

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/EnableCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/EnableCollaboratorUseCase.java
@@ -6,6 +6,8 @@ import br.com.chronos.core.modules.collaboration.domain.exceptions.CollaboratorN
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Id;
+import br.com.chronos.core.modules.global.domain.records.Role;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 
 public class EnableCollaboratorUseCase {
   private final CollaboratorsRepository repository;
@@ -14,10 +16,9 @@ public class EnableCollaboratorUseCase {
     this.repository = repository;
   }
 
-  public void execute(String collaboratorId, Email responsibleEmail) {
-    var responsible = this.repository.findByEmail(responsibleEmail);
+  public void execute(String collaboratorId, Sector responsibleSector, Role responsibleRole) {
     var collaborator = findCollaborator(Id.create(collaboratorId));
-    if (!responsible.get().isFromSameSector(collaborator).value()) {
+    if (collaborator.isFromSameSector(responsibleSector,responsibleRole).isFalse()) {
       throw new NotAuthorizedException();
 
     }

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/ListCollaboratorsUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/ListCollaboratorsUseCase.java
@@ -2,6 +2,7 @@ package br.com.chronos.core.modules.collaboration.use_cases;
 
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
+import br.com.chronos.core.modules.global.domain.records.Logical;
 import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 import br.com.chronos.core.modules.global.domain.records.Role.RoleName;
@@ -14,8 +15,8 @@ public class ListCollaboratorsUseCase {
     this.repository = repository;
   }
 
-  public PaginationResponse<CollaboratorDto> execute(int page, RoleName requesterRole, Sector requesterSector) {
-    var collaboratorsCollection = repository.findMany(PageNumber.create(page), requesterRole, requesterSector);
+  public PaginationResponse<CollaboratorDto> execute(int page, RoleName requesterRole, Sector requesterSector,Logical isActive) {
+    var collaboratorsCollection = repository.findMany(PageNumber.create(page), requesterRole, requesterSector,isActive);
     var dtos = collaboratorsCollection.getFirst().map(collaborator -> collaborator.getDto()).list();
     var itemsCount = collaboratorsCollection.getSecond();
     return new PaginationResponse<CollaboratorDto>(dtos, itemsCount.value());

--- a/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/UpdateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/collaboration/use_cases/UpdateCollaboratorUseCase.java
@@ -12,6 +12,7 @@ import br.com.chronos.core.modules.global.domain.records.Cpf;
 import br.com.chronos.core.modules.global.domain.records.Email;
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Role;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
 
 public class UpdateCollaboratorUseCase {
   private final CollaboratorsRepository repository;
@@ -21,7 +22,7 @@ public class UpdateCollaboratorUseCase {
   }
 
   public CollaboratorDto execute(String collaboratorId, CollaboratorDto dto, Id workScheduleId,
-      CollaborationSector responsibleSector, Role responsibleRole) {
+      Sector responsibleSector, Role responsibleRole) {
     if (dto == null) {
       dto = new CollaboratorDto();
     }

--- a/src/main/java/br/com/chronos/core/modules/global/domain/records/PageNumber.java
+++ b/src/main/java/br/com/chronos/core/modules/global/domain/records/PageNumber.java
@@ -2,16 +2,16 @@ package br.com.chronos.core.modules.global.domain.records;
 
 import br.com.chronos.core.modules.global.domain.exceptions.ValidationException;
 
-public record Page(PlusInteger number) {
+public record PageNumber(PlusInteger number) {
   private static String KEY = "número da paginação";
 
-  public static Page create(int value) {
+  public static PageNumber create(int value) {
     var number = PlusInteger.create(value, KEY);
 
     if (number.value() == 0) {
       throw new ValidationException(KEY, "deve ser maior que zero");
     }
 
-    return new Page(number);
+    return new PageNumber(number);
   }
 }

--- a/src/main/java/br/com/chronos/core/modules/work_schedule/interfaces/repositories/WorkSchedulesRepository.java
+++ b/src/main/java/br/com/chronos/core/modules/work_schedule/interfaces/repositories/WorkSchedulesRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Logical;
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.PlusInteger;
 import br.com.chronos.core.modules.global.domain.records.Array;
 import br.com.chronos.core.modules.work_schedule.domain.entities.TimePunch;
@@ -20,7 +20,7 @@ public interface WorkSchedulesRepository {
 
   Array<Id> findCollaboratorIdsByWorkSchedule(WorkSchedule workSchedule);
 
-  Pair<Array<WorkSchedule>, PlusInteger> findMany(Page page);
+  Pair<Array<WorkSchedule>, PlusInteger> findMany(PageNumber page);
 
   void add(WorkSchedule workSchedule);
 

--- a/src/main/java/br/com/chronos/core/modules/work_schedule/interfaces/repositories/WorkdayLogsRepository.java
+++ b/src/main/java/br/com/chronos/core/modules/work_schedule/interfaces/repositories/WorkdayLogsRepository.java
@@ -6,7 +6,7 @@ import br.com.chronos.core.modules.global.domain.records.Date;
 import br.com.chronos.core.modules.global.domain.records.DateRange;
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Logical;
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.PlusInteger;
 import br.com.chronos.core.modules.global.domain.records.Array;
 import br.com.chronos.core.modules.work_schedule.domain.entities.TimePunch;
@@ -19,9 +19,9 @@ public interface WorkdayLogsRepository {
   Pair<Array<WorkdayLog>, PlusInteger> findManyByCollaboratorAndDateRange(
       Id collaboratorId,
       DateRange dateRange,
-      Page page);
+      PageNumber page);
 
-  Pair<Array<WorkdayLog>, PlusInteger> findManyByDate(Date date, Page page);
+  Pair<Array<WorkdayLog>, PlusInteger> findManyByDate(Date date, PageNumber page);
 
   void addMany(Array<WorkdayLog> workdayLogs);
 

--- a/src/main/java/br/com/chronos/core/modules/work_schedule/use_cases/ListCollaboratorWorkdayLogsUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/work_schedule/use_cases/ListCollaboratorWorkdayLogsUseCase.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 import br.com.chronos.core.modules.global.domain.records.DateRange;
 import br.com.chronos.core.modules.global.domain.records.Id;
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 import br.com.chronos.core.modules.work_schedule.domain.dtos.WorkdayLogDto;
 import br.com.chronos.core.modules.work_schedule.interfaces.repositories.WorkdayLogsRepository;
@@ -25,7 +25,7 @@ public class ListCollaboratorWorkdayLogsUseCase {
     var response = repository.findManyByCollaboratorAndDateRange(
         Id.create(collaboratorId),
         DateRange.create(startDate, endDate),
-        Page.create(page));
+        PageNumber.create(page));
     var workdayLogs = response.getFirst().map((workdayLog) -> workdayLog.getDto());
     var itemsCount = response.getSecond();
 

--- a/src/main/java/br/com/chronos/core/modules/work_schedule/use_cases/ListWorkSchedulesUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/work_schedule/use_cases/ListWorkSchedulesUseCase.java
@@ -1,6 +1,6 @@
 package br.com.chronos.core.modules.work_schedule.use_cases;
 
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 import br.com.chronos.core.modules.work_schedule.domain.dtos.WorkScheduleDto;
 import br.com.chronos.core.modules.work_schedule.interfaces.repositories.WorkSchedulesRepository;
@@ -13,7 +13,7 @@ public class ListWorkSchedulesUseCase {
   }
 
   public PaginationResponse<WorkScheduleDto> execute(int page) {
-    var response = repository.findMany(Page.create(page));
+    var response = repository.findMany(PageNumber.create(page));
     var workSchedules = response.getFirst().map(workSchedule -> workSchedule.getDto());
     var itemsCount = response.getSecond();
 

--- a/src/main/java/br/com/chronos/core/modules/work_schedule/use_cases/ReportWorkdayHistoryUseCase.java
+++ b/src/main/java/br/com/chronos/core/modules/work_schedule/use_cases/ReportWorkdayHistoryUseCase.java
@@ -3,7 +3,7 @@ package br.com.chronos.core.modules.work_schedule.use_cases;
 import java.time.LocalDate;
 
 import br.com.chronos.core.modules.global.domain.records.Date;
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 import br.com.chronos.core.modules.work_schedule.domain.dtos.WorkdayLogDto;
 import br.com.chronos.core.modules.work_schedule.interfaces.repositories.WorkdayLogsRepository;
@@ -16,7 +16,7 @@ public class ReportWorkdayHistoryUseCase {
   }
 
   public PaginationResponse<WorkdayLogDto> execute(LocalDate date, int page) {
-    var response = repository.findManyByDate(Date.create(date), Page.create(page));
+    var response = repository.findManyByDate(Date.create(date), PageNumber.create(page));
     var workdayLogs = response.getFirst().map(workdayLog -> workdayLog.getDto());
     var itemsCount = response.getSecond();
 

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/CreateCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/CreateCollaboratorController.java
@@ -41,9 +41,10 @@ public class CreateCollaboratorController {
     var password = Password.create(body.password);
     var workScheduleId = Id.create(body.workScheduleId);
     var responsible = authenticationProvider.getAuthenticatedUser();
-    var responsibleSector = responsible.getSector();
+    var responsibleSector = responsible.getSector().value();
     var responsibleRole = responsible.getRole();
-    var collaboratorDto = useCase.execute(body.collaboratorDto, workScheduleId, password, responsibleSector,responsibleRole);
+    var collaboratorDto = useCase.execute(body.collaboratorDto, workScheduleId, password, responsibleSector,
+        responsibleRole);
     return ResponseEntity.status(HttpStatus.OK).body(collaboratorDto);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/DisableCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/DisableCollaboratorController.java
@@ -23,8 +23,10 @@ public class DisableCollaboratorController {
   @DeleteMapping("/disable/{id}")
   public ResponseEntity<CollaboratorDto> handle(@PathVariable("id") String collaboratorId) {
     var useCase = new DisableCollaboratorUseCase(repository);
-    var responsibleEmail = authenticationProvider.getAuthenticatedUser().getEmail();
-    useCase.execute(collaboratorId, responsibleEmail);
+    var responsible = authenticationProvider.getAuthenticatedUser();
+    var sector = responsible.getSector().value();
+    var role = responsible.getRole();
+    useCase.execute(collaboratorId, sector, role);
     return ResponseEntity.status(HttpStatus.OK).body(null);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/EnableCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/EnableCollaboratorController.java
@@ -23,8 +23,10 @@ public class EnableCollaboratorController {
   @PostMapping("/enable/{id}")
   public ResponseEntity<CollaboratorDto> handle(@PathVariable("id") String collaboratorId) {
     var useCase = new EnableCollaboratorUseCase(repository);
-    var responsibleEmail = this.authenticationProvider.getAuthenticatedUser().getEmail();
-    useCase.execute(collaboratorId, responsibleEmail);
-    return ResponseEntity.status(HttpStatus.OK).body(null);
+    var responsible = this.authenticationProvider.getAuthenticatedUser();
+    var sector = responsible.getSector().value();
+    var role = responsible.getRole();
+    useCase.execute(collaboratorId, sector, role);
+    return ResponseEntity.ok(null);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/ListCollaboratorsController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/ListCollaboratorsController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.modules.collaboration.use_cases.ListCollaboratorsUseCase;
+import br.com.chronos.core.modules.global.domain.records.Logical;
 import br.com.chronos.core.modules.global.interfaces.providers.AuthenticationProvider;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 
@@ -21,12 +22,13 @@ public class ListCollaboratorsController {
   private AuthenticationProvider authenticationProvider;
 
   @GetMapping
-  public ResponseEntity<PaginationResponse<CollaboratorDto>> handle(@RequestParam(defaultValue = "1") int page) {
+  public ResponseEntity<PaginationResponse<CollaboratorDto>> handle(@RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "true",name = "active") boolean isActive) {
     var useCase = new ListCollaboratorsUseCase(repository);
     var responsible = authenticationProvider.getAuthenticatedUser();
     var sector = responsible.getSector().value();
     var role = responsible.getRole();
-    var response = useCase.execute(page,role.value(),sector);
+    var response = useCase.execute(page, role.value(), sector, Logical.create(isActive));
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/ListCollaboratorsController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/ListCollaboratorsController.java
@@ -18,6 +18,9 @@ public class ListCollaboratorsController {
   @Autowired
   private CollaboratorsRepository repository;
 
+  @Autowired
+  private AuthenticationProvider authenticationProvider;
+
   @GetMapping
   public ResponseEntity<PaginationResponse<CollaboratorDto>> handle(@RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "true",name = "active") boolean isActive) {

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/ListCollaboratorsController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/ListCollaboratorsController.java
@@ -24,9 +24,9 @@ public class ListCollaboratorsController {
   public ResponseEntity<PaginationResponse<CollaboratorDto>> handle(@RequestParam(defaultValue = "1") int page) {
     var useCase = new ListCollaboratorsUseCase(repository);
     var responsible = authenticationProvider.getAuthenticatedUser();
-    var sector = responsible.getSector();
+    var sector = responsible.getSector().value();
     var role = responsible.getRole();
-    var response = useCase.execute(page,role.value(),sector.value());
+    var response = useCase.execute(page,role.value(),sector);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/UpdateCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/UpdateCollaboratorController.java
@@ -33,7 +33,7 @@ public class UpdateCollaboratorController {
       @RequestBody Request body) {
     var useCase = new UpdateCollaboratorUseCase(repository);
     var responsible = authenticationProvider.getAuthenticatedUser();
-    var responsibleSector = responsible.getSector();
+    var responsibleSector = responsible.getSector().value();
     var responsibleRole = responsible.getRole();
     Id workScheduleId = body.workScheduleId != null ? Id.create(body.workScheduleId) : null;
     var response = useCase.execute(collaboratorId, body.collaboratorDto,  workScheduleId,responsibleSector,responsibleRole);

--- a/src/main/java/br/com/chronos/server/database/jpa/collaborator/repositories/JpaCollaboratorsRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/collaborator/repositories/JpaCollaboratorsRepository.java
@@ -4,7 +4,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
@@ -16,6 +18,8 @@ import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Logical;
 import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.PlusInteger;
+import br.com.chronos.core.modules.global.domain.records.CollaborationSector.Sector;
+import br.com.chronos.core.modules.global.domain.records.Role.RoleName;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 import br.com.chronos.server.database.jpa.collaborator.mappers.CollaboratorMapper;
 import br.com.chronos.server.database.jpa.collaborator.models.CollaboratorModel;
@@ -91,7 +95,8 @@ public class JpaCollaboratorsRepository implements CollaboratorsRepository {
     if (requesterRole == RoleName.ADMIN) {
       collaboratorModels = repository.findAllByAccountRoleNot(RoleName.ADMIN, pageRequest);
     } else {
-      collaboratorModels = repository.findAllByAccountRoleNotAndAccountSectorAndAccountIsActive(RoleName.ADMIN, requesterSector,
+      collaboratorModels = repository.findAllByAccountRoleNotAndAccountSectorAndAccountIsActive(RoleName.ADMIN,
+          requesterSector,
           isActive.value(), pageRequest);
     }
     System.out.println(collaboratorModels);

--- a/src/main/java/br/com/chronos/server/database/jpa/work_schedule/repositories/JpaWorkSchedulesRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/work_schedule/repositories/JpaWorkSchedulesRepository.java
@@ -16,7 +16,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import br.com.chronos.core.modules.global.domain.records.Array;
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Logical;
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.PlusInteger;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 import br.com.chronos.core.modules.work_schedule.domain.entities.TimePunch;
@@ -101,7 +101,7 @@ public class JpaWorkSchedulesRepository implements WorkSchedulesRepository {
   }
 
   @Override
-  public Pair<Array<WorkSchedule>, PlusInteger> findMany(Page page) {
+  public Pair<Array<WorkSchedule>, PlusInteger> findMany(PageNumber page) {
     var pageRequest = PageRequest.of(page.number().value() - 1, PaginationResponse.ITEMS_PER_PAGE);
     var workScheduleModels = workScheduleModelsRepository.findAll(pageRequest);
     var items = workScheduleModels.stream().toList();

--- a/src/main/java/br/com/chronos/server/database/jpa/work_schedule/repositories/JpaWorkdayLogsRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/work_schedule/repositories/JpaWorkdayLogsRepository.java
@@ -18,7 +18,7 @@ import br.com.chronos.core.modules.global.domain.records.Date;
 import br.com.chronos.core.modules.global.domain.records.DateRange;
 import br.com.chronos.core.modules.global.domain.records.Id;
 import br.com.chronos.core.modules.global.domain.records.Logical;
-import br.com.chronos.core.modules.global.domain.records.Page;
+import br.com.chronos.core.modules.global.domain.records.PageNumber;
 import br.com.chronos.core.modules.global.domain.records.PlusInteger;
 import br.com.chronos.core.modules.global.responses.PaginationResponse;
 import br.com.chronos.core.modules.work_schedule.domain.entities.TimePunch;
@@ -103,7 +103,7 @@ public class JpaWorkdayLogsRepository implements WorkdayLogsRepository {
   public Pair<Array<WorkdayLog>, PlusInteger> findManyByCollaboratorAndDateRange(
       Id collaboratorId,
       DateRange dateRange,
-      Page page) {
+      PageNumber page) {
 
     var pageRequest = PageRequest.of(page.number().value(), PaginationResponse.ITEMS_PER_PAGE);
     var collaboratorModel = CollaboratorModel.builder().id(collaboratorId.value()).build();
@@ -116,7 +116,7 @@ public class JpaWorkdayLogsRepository implements WorkdayLogsRepository {
   }
 
   @Override
-  public Pair<Array<WorkdayLog>, PlusInteger> findManyByDate(Date date, Page page) {
+  public Pair<Array<WorkdayLog>, PlusInteger> findManyByDate(Date date, PageNumber page) {
     var pageRequest = PageRequest.of(page.number().value(), PaginationResponse.ITEMS_PER_PAGE);
     var workdayLogModels = repository.findAllByDate(date.value(), pageRequest);
     var items = workdayLogModels.getContent().stream().toList();

--- a/src/main/java/br/com/chronos/server/infra/security/SecurityConfiguration.java
+++ b/src/main/java/br/com/chronos/server/infra/security/SecurityConfiguration.java
@@ -29,7 +29,7 @@ public class SecurityConfiguration {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
             .requestMatchers("/collaboration/collaborator").hasRole("MANAGER")
-            .anyRequest().permitAll())
+            .anyRequest().authenticated())
         .addFilterBefore(securityJwtFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }


### PR DESCRIPTION
## Changelog for `list-all-collaborators-fix`

**Branch**: `list-all-collaborators-fix`

**Main Purpose**:  
- Add protection to the "list collaborators" feature.  
- Fix enabling and disabling collaborators' accounts.  
- Reinstate all validation logic in the project.

**Changelog**:  
- Renamed `Page` to `PageNumber` .  
- Added an `active` query parameter to the "list collaborators" endpoint to filter based on status.  
- Fixed the logic for enabling collaborators' accounts.  
- Fixed the logic for disabling collaborators' accounts.  
- Added two new queries to `JpaCollaboratorsRepository` (purely in JPA, no SQL needed).  
- Re-enabled route protection across the entire project.

I was in the middle of everything when @FaelSantoss asked for help with some schema errors, and I ended up accidentally pushing all my unfinished stuff to `main` 😢😢😭.Thats why there is a bunch of ```fix``` merge conflict in both ```main``` and ```list-all-collaborators-fix```
