### PR TITLE
Solicitation repository

### DIFF
--- a/src/main/java/br/com/chronos/core/modules/solicitation/domain/abstracts/Solicitation.java
+++ b/src/main/java/br/com/chronos/core/modules/solicitation/domain/abstracts/Solicitation.java
@@ -25,6 +25,11 @@ public abstract class Solicitation extends Entity {
     replierResponsible = new ResponsibleAggregate(dto.replierResponsible);
   }
 
+  public Text getDescription(){
+    return description;
+  }
+  
+
   public SolicitationStatus getStatus() {
     return status;
   }

--- a/src/main/java/br/com/chronos/core/modules/solicitation/domain/dtos/TimePunchLogAdjustmentSolicitationDto.java
+++ b/src/main/java/br/com/chronos/core/modules/solicitation/domain/dtos/TimePunchLogAdjustmentSolicitationDto.java
@@ -1,6 +1,9 @@
 package br.com.chronos.core.modules.solicitation.domain.dtos;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
+
+import br.com.chronos.core.modules.global.domain.dtos.ResponsibleAggregateDto;
 
 public class TimePunchLogAdjustmentSolicitationDto extends SolicitationDto {
   public LocalTime time;
@@ -13,6 +16,41 @@ public class TimePunchLogAdjustmentSolicitationDto extends SolicitationDto {
 
   public TimePunchLogAdjustmentSolicitationDto setPeriod(String period) {
     this.period = period;
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setId(String id) {
+    super.setId(id);
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setDescription(String description) {
+    super.setDescription(description);
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setDate(LocalDate date) {
+    super.setDate(date);
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setStatus(String status) {
+    super.setStatus(status);
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setFeedbackMessage(String feedbackMessage) {
+    super.setFeedbackMessage(feedbackMessage);
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setSenderResponsible(ResponsibleAggregateDto senderResponsible) {
+    super.setSenderResponsible(senderResponsible);
+    return this;
+  }
+
+  public TimePunchLogAdjustmentSolicitationDto setReplierResponsible(ResponsibleAggregateDto replierResponsible) {
+    super.setReplierResponsible(replierResponsible);
     return this;
   }
 }

--- a/src/main/java/br/com/chronos/server/database/DatabaseConfiguration.java
+++ b/src/main/java/br/com/chronos/server/database/DatabaseConfiguration.java
@@ -5,11 +5,13 @@ import org.springframework.context.annotation.Configuration;
 
 import br.com.chronos.core.modules.auth.interfaces.repositories.AccountsRepository;
 import br.com.chronos.core.modules.collaboration.interfaces.repositories.CollaboratorsRepository;
+import br.com.chronos.core.modules.solicitation.interfaces.repository.SolicitationsRepository;
 import br.com.chronos.core.modules.work_schedule.interfaces.repositories.TimePunchesRepository;
 import br.com.chronos.core.modules.work_schedule.interfaces.repositories.WorkSchedulesRepository;
 import br.com.chronos.core.modules.work_schedule.interfaces.repositories.WorkdayLogsRepository;
 import br.com.chronos.server.database.jpa.auth.repositories.JpaAccountsRepository;
 import br.com.chronos.server.database.jpa.collaborator.repositories.JpaCollaboratorsRepository;
+import br.com.chronos.server.database.jpa.solicitation.repositories.JpaSolicitationsRepository;
 import br.com.chronos.server.database.jpa.work_schedule.repositories.JpaTimePunchesRepository;
 import br.com.chronos.server.database.jpa.work_schedule.repositories.JpaWorkSchedulesRepository;
 import br.com.chronos.server.database.jpa.work_schedule.repositories.JpaWorkdayLogsRepository;
@@ -20,6 +22,11 @@ public class DatabaseConfiguration {
   @Bean
   TimePunchesRepository timePunchesRepository() {
     return new JpaTimePunchesRepository();
+  }
+
+  @Bean
+  SolicitationsRepository solicitationsRepository(){
+    return new JpaSolicitationsRepository();
   }
 
   @Bean

--- a/src/main/java/br/com/chronos/server/database/jpa/auth/mappers/AccountMapper.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/auth/mappers/AccountMapper.java
@@ -1,12 +1,13 @@
 package br.com.chronos.server.database.jpa.auth.mappers;
 
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import br.com.chronos.core.modules.auth.domain.dtos.AccountDto;
 import br.com.chronos.core.modules.auth.domain.entities.Account;
 import br.com.chronos.server.database.jpa.auth.models.AccountModel;
 
-@Service
+@Component
 public class AccountMapper {
   public AccountModel toModel(Account entity) {
     var model = AccountModel.builder()

--- a/src/main/java/br/com/chronos/server/database/jpa/collaborator/mappers/CollaboratorMapper.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/collaborator/mappers/CollaboratorMapper.java
@@ -1,12 +1,13 @@
 package br.com.chronos.server.database.jpa.collaborator.mappers;
 
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import br.com.chronos.core.modules.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.modules.collaboration.domain.entities.Collaborator;
 import br.com.chronos.server.database.jpa.collaborator.models.CollaboratorModel;
 
-@Service
+@Component
 public class CollaboratorMapper {
   public CollaboratorModel toModel(Collaborator entity) {
     var model = CollaboratorModel.builder()

--- a/src/main/java/br/com/chronos/server/database/jpa/collaborator/models/CollaboratorModel.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/collaborator/models/CollaboratorModel.java
@@ -19,7 +19,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import br.com.chronos.server.database.jpa.auth.models.AccountModel;
-import br.com.chronos.server.database.jpa.solicitation.models.WorkdayLogAdjustmentSolicitationModel;
+import br.com.chronos.server.database.jpa.solicitation.models.TimePunchLogAdjustmentSolicitationModel;
 import br.com.chronos.server.database.jpa.work_schedule.models.WorkScheduleModel;
 import br.com.chronos.server.database.jpa.work_schedule.models.WorkdayLogModel;
 
@@ -52,10 +52,10 @@ public class CollaboratorModel {
 
   @OneToMany(mappedBy = "senderResponsible", fetch = FetchType.LAZY)
   @Builder.Default
-  private List<WorkdayLogAdjustmentSolicitationModel> sentSolicitations = new ArrayList<>();
+  private List<TimePunchLogAdjustmentSolicitationModel> sentSolicitations = new ArrayList<>();
 
   @OneToMany(mappedBy = "replierResponsible", fetch = FetchType.LAZY)
   @Builder.Default
-  private List<WorkdayLogAdjustmentSolicitationModel> repliedSolicitations = new ArrayList<>();
+  private List<TimePunchLogAdjustmentSolicitationModel> repliedSolicitations = new ArrayList<>();
 
 }

--- a/src/main/java/br/com/chronos/server/database/jpa/collaborator/repositories/JpaCollaboratorsRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/collaborator/repositories/JpaCollaboratorsRepository.java
@@ -31,7 +31,7 @@ interface JpaCollaboratorModelsRepository extends JpaRepository<CollaboratorMode
 
   public Optional<CollaboratorModel> findByCpf(String cpf);
 
-  Page<CollaboratorModel> findAllByAccountRoleNot(RoleName role, Pageable pageable);
+  Page<CollaboratorModel> findAllByAccountRoleNotAndAccountIsActive(RoleName role, Pageable pageable, Boolean isActive);
 
   Page<CollaboratorModel> findAllByAccountRoleNotAndAccountSectorAndAccountIsActive(
       RoleName role,
@@ -93,7 +93,8 @@ public class JpaCollaboratorsRepository implements CollaboratorsRepository {
     var pageRequest = PageRequest.of(page.number().value() - 1, PaginationResponse.ITEMS_PER_PAGE);
     Page<CollaboratorModel> collaboratorModels;
     if (requesterRole == RoleName.ADMIN) {
-      collaboratorModels = repository.findAllByAccountRoleNot(RoleName.ADMIN, pageRequest);
+      collaboratorModels = repository.findAllByAccountRoleNotAndAccountIsActive(RoleName.ADMIN, pageRequest,
+          isActive.value());
     } else {
       collaboratorModels = repository.findAllByAccountRoleNotAndAccountSectorAndAccountIsActive(RoleName.ADMIN,
           requesterSector,

--- a/src/main/java/br/com/chronos/server/database/jpa/solicitation/mappers/TimePunchLogAdjustmentSolicitationMapper.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/solicitation/mappers/TimePunchLogAdjustmentSolicitationMapper.java
@@ -1,0 +1,57 @@
+package br.com.chronos.server.database.jpa.solicitation.mappers;
+
+import org.springframework.stereotype.Component;
+
+import br.com.chronos.core.modules.global.domain.dtos.ResponsibleAggregateDto;
+import br.com.chronos.core.modules.global.domain.dtos.ResponsibleDto;
+import br.com.chronos.core.modules.solicitation.domain.dtos.TimePunchLogAdjustmentSolicitationDto;
+import br.com.chronos.core.modules.solicitation.domain.entities.TimePunchLogAdjustmentSolicitation;
+import br.com.chronos.server.database.jpa.collaborator.models.CollaboratorModel;
+import br.com.chronos.server.database.jpa.solicitation.models.TimePunchLogAdjustmentSolicitationModel;
+
+@Component
+public class TimePunchLogAdjustmentSolicitationMapper {
+
+  public TimePunchLogAdjustmentSolicitationModel toModel(TimePunchLogAdjustmentSolicitation entity) {
+    var senderResponsible = CollaboratorModel.builder().id(entity.getSenderResponsible().getId().value()).build();
+    var replierResponsible = CollaboratorModel.builder().id(entity.getReplierResponsible().getId().value()).build();
+    return TimePunchLogAdjustmentSolicitationModel.builder()
+        .id(entity.getId().value())
+        .description(entity.getDescription().value())
+        .request_at(entity.getDate().value())
+        .feedbackMessage(entity.getFeedbackMessage().value())
+        .solicitationStatus(entity.getStatus().value())
+        .time(entity.getTime().value())
+        .timePunchPeriod(entity.getPeriod().name())
+        .senderResponsible(senderResponsible)
+        .replierResponsible(replierResponsible).build();
+
+  }
+  public TimePunchLogAdjustmentSolicitation toEntity(TimePunchLogAdjustmentSolicitationModel model){
+
+    var senderResponsibleDto = new ResponsibleDto()
+    .setId(model.getSenderResponsible().getId().toString())
+    .setName(model.getSenderResponsible().getName())
+    .setEmail(model.getSenderResponsible().getAccount().getEmail())
+    .setRole(model.getSenderResponsible().getAccount().getRole().toString());
+    var senderResponsibleAggregateDto = new ResponsibleAggregateDto()
+    .setResponsibleDto(senderResponsibleDto);
+    var replierResponsibleDto = new ResponsibleDto()
+    .setId(model.getReplierResponsible().getId().toString())
+    .setName(model.getReplierResponsible().getName())
+    .setEmail(model.getReplierResponsible().getAccount().getEmail())
+    .setRole(model.getReplierResponsible().getAccount().getRole().toString());
+    var replierResponsibleAggregateDto = new ResponsibleAggregateDto().setResponsibleDto(replierResponsibleDto);
+    var dto = new TimePunchLogAdjustmentSolicitationDto()
+    .setTime(model.getTime())
+    .setId(model.getId().toString())
+    .setDescription(model.getDescription().toString())
+    .setDate(model.getRequest_at())
+    .setStatus(model.getSolicitationStatus().toString())
+    .setFeedbackMessage(model.getFeedbackMessage().toString())
+    .setSenderResponsible(senderResponsibleAggregateDto)
+    .setReplierResponsible(replierResponsibleAggregateDto);
+    
+    return new TimePunchLogAdjustmentSolicitation(dto);
+  }
+}

--- a/src/main/java/br/com/chronos/server/database/jpa/solicitation/models/TimePunchLogAdjustmentSolicitationModel.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/solicitation/models/TimePunchLogAdjustmentSolicitationModel.java
@@ -1,12 +1,11 @@
 package br.com.chronos.server.database.jpa.solicitation.models;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Date;
 import java.util.UUID;
 
-import br.com.chronos.core.modules.solicitation.domain.records.SolicitationStatus;
 import br.com.chronos.core.modules.solicitation.domain.records.SolicitationStatus.Status;
-import br.com.chronos.core.modules.work_schedule.domain.records.TimePunchPeriod;
 import br.com.chronos.core.modules.work_schedule.domain.records.TimePunchPeriod.PeriodName;
 import br.com.chronos.server.database.jpa.collaborator.models.CollaboratorModel;
 import br.com.chronos.server.database.jpa.work_schedule.models.WorkdayLogModel;
@@ -28,8 +27,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "workday_log_adjustment_requests")
-public class WorkdayLogAdjustmentSolicitationModel {
+@Table(name = "time_punch_log_adjustment_solicitation")
+public class TimePunchLogAdjustmentSolicitationModel {
   @Id
   private UUID id;
 
@@ -37,7 +36,7 @@ public class WorkdayLogAdjustmentSolicitationModel {
   private String description;
 
   @Column(nullable = false)
-  private Date request_at;
+  private LocalDate request_at;
 
   @Column(nullable = true)
   private String feedbackMessage;

--- a/src/main/java/br/com/chronos/server/database/jpa/solicitation/repositories/JpaSolicitationsRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/solicitation/repositories/JpaSolicitationsRepository.java
@@ -1,0 +1,32 @@
+package br.com.chronos.server.database.jpa.solicitation.repositories;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.com.chronos.core.modules.solicitation.domain.entities.TimePunchLogAdjustmentSolicitation;
+import br.com.chronos.core.modules.solicitation.interfaces.repository.SolicitationsRepository;
+import br.com.chronos.server.database.jpa.solicitation.mappers.TimePunchLogAdjustmentSolicitationMapper;
+import br.com.chronos.server.database.jpa.solicitation.models.TimePunchLogAdjustmentSolicitationModel;
+
+interface JpaTimePunchLogAdjustmentSolicitationModelsRepository
+    extends JpaRepository<TimePunchLogAdjustmentSolicitationModel, UUID> {
+}
+public class JpaSolicitationsRepository implements SolicitationsRepository{
+
+  @Autowired
+  JpaTimePunchLogAdjustmentSolicitationModelsRepository timePunchLogAdjustmentSolicitationModelsRepository;
+
+  @Autowired
+  TimePunchLogAdjustmentSolicitationMapper mapper;
+
+	@Override
+	public void addTimePunchLogAdjustmentSolicitation(TimePunchLogAdjustmentSolicitation solicitation) {
+    var timePunchAdjustmentSolicitationModel = mapper.toModel(solicitation);
+    timePunchLogAdjustmentSolicitationModelsRepository.save(timePunchAdjustmentSolicitationModel);
+	}
+
+
+
+}

--- a/src/main/java/br/com/chronos/server/database/jpa/work_schedule/mappers/WorkdayLogMapper.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/work_schedule/mappers/WorkdayLogMapper.java
@@ -1,6 +1,7 @@
 package br.com.chronos.server.database.jpa.work_schedule.mappers;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import br.com.chronos.core.modules.global.domain.dtos.ResponsibleAggregateDto;
@@ -10,7 +11,7 @@ import br.com.chronos.core.modules.work_schedule.domain.entities.WorkdayLog;
 import br.com.chronos.server.database.jpa.collaborator.models.CollaboratorModel;
 import br.com.chronos.server.database.jpa.work_schedule.models.WorkdayLogModel;
 
-@Service
+@Component
 public class WorkdayLogMapper {
   @Autowired
   private TimePunchMapper TimePunchMapper;
@@ -33,7 +34,7 @@ public class WorkdayLogMapper {
 
   public WorkdayLog toEntity(WorkdayLogModel model) {
     var responsibleDto = new ResponsibleDto()
-        .setId(model.getCollaborator().toString())
+        .setId(model.getCollaborator().getId().toString())
         .setName(model.getCollaborator().getName())
         .setEmail(model.getCollaborator().getAccount().getEmail())
         .setRole(model.getCollaborator().getAccount().getRole().toString());

--- a/src/main/java/br/com/chronos/server/database/jpa/work_schedule/models/WorkdayLogModel.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/work_schedule/models/WorkdayLogModel.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 
 import br.com.chronos.core.modules.work_schedule.domain.records.WorkdayStatus.WorkdayStatusName;
 import br.com.chronos.server.database.jpa.collaborator.models.CollaboratorModel;
-import br.com.chronos.server.database.jpa.solicitation.models.WorkdayLogAdjustmentSolicitationModel;
+import br.com.chronos.server.database.jpa.solicitation.models.TimePunchLogAdjustmentSolicitationModel;
 
 @Entity
 @AllArgsConstructor
@@ -53,5 +53,5 @@ public class WorkdayLogModel {
   private WorkdayStatusName status;
 
   @OneToMany(mappedBy = "workdayLog")
-  private List<WorkdayLogAdjustmentSolicitationModel> workdayLogAdjustmentSolicitation;
+  private List<TimePunchLogAdjustmentSolicitationModel> workdayLogAdjustmentSolicitation;
 }


### PR DESCRIPTION
## Branch: `solicitation-repository`

### Main Purpose  
Implement the `SolicitationRepository` to manage solicitation data.

### Changelog  
- **Added** `timePunchAdjustmentDtoMapper`.  
- **Added** setters to `timePunchAdjustmentSolicitationDto`.  
- **Added** `SolicitationRepository`.  
- **Changed** `@Service` to `@Component` in all mappers to fllow a pattern in dependency injection management.  
- **Changed** `WorkdayLogAdjustmentSolicitation` to `TimePunchAdjustmentSolicitation`
- **Fixed** `setId` in `toEntity` in `WorkDayLogMapper` to correctly retrieve the ID instead of the collaborator entity.  
- **Fixed** now `Solicitation` has an `getDescription`
