### PR TITLE
Refactor update account

### DIFF
--- a/src/main/java/br/com/chronos/core/auth/domain/entities/Account.java
+++ b/src/main/java/br/com/chronos/core/auth/domain/entities/Account.java
@@ -82,7 +82,12 @@ public final class Account extends Entity {
   public void updatePassword(Password password) {
     this.password = password;
   }
-
+  public void updateRole(Role role) {
+    this.role = role;
+  }
+  public void updateCollaborationSector(CollaborationSector collaborationSector) {
+    this.collaborationSector = collaborationSector;
+  }
   public Role getRole() {
     return role;
   }

--- a/src/main/java/br/com/chronos/core/auth/use_cases/UpdateAccountUseCase.java
+++ b/src/main/java/br/com/chronos/core/auth/use_cases/UpdateAccountUseCase.java
@@ -1,0 +1,37 @@
+package br.com.chronos.core.auth.use_cases;
+
+import br.com.chronos.core.auth.domain.dtos.AccountDto;
+import br.com.chronos.core.auth.domain.entities.Account;
+import br.com.chronos.core.auth.domain.exceptions.AccountNotFoundException;
+import br.com.chronos.core.auth.domain.exceptions.NotAuthorizedException;
+import br.com.chronos.core.auth.interfaces.repositories.AccountsRepository;
+import br.com.chronos.core.global.domain.records.CollaborationSector;
+import br.com.chronos.core.global.domain.records.Email;
+import br.com.chronos.core.global.domain.records.Id;
+import br.com.chronos.core.global.domain.records.Role;
+
+public class UpdateAccountUseCase {
+  private final AccountsRepository accountsRepository;
+
+  public UpdateAccountUseCase(AccountsRepository accountsRepository) {
+    this.accountsRepository = accountsRepository;
+  }
+
+  public void execute(AccountDto accountDto, String responsibleCollaboratorId) {
+    var account = findAccount(Id.create(accountDto.collaboratorId));
+    var responsibleAccount = findAccount(Id.create(responsibleCollaboratorId));
+    account.updateEmail(Email.create(accountDto.email));
+    account.updateRole(Role.create(accountDto.role));
+    account.updateCollaborationSector(CollaborationSector.create(accountDto.collaborationSector));
+    this.accountsRepository.replace(account);
+  }
+
+  public Account findAccount(Id collaboratorId) {
+    var account = this.accountsRepository.findByCollaborator(collaboratorId);
+    if (account.isEmpty()) {
+      throw new AccountNotFoundException();
+    }
+    return account.get();
+
+  }
+}

--- a/src/main/java/br/com/chronos/core/collaboration/domain/entities/Collaborator.java
+++ b/src/main/java/br/com/chronos/core/collaboration/domain/entities/Collaborator.java
@@ -67,22 +67,22 @@ public final class Collaborator extends Entity {
   }
 
   public void update(CollaboratorDto dto) {
-    if (dto.name != null) {
+    if (dto.name != null && dto.name != this.getName().value()) {
       this.name = Text.create(dto.name, "Collaborator name");
     }
-    if (dto.email != null) {
+    if (dto.email != null && dto.email != this.getEmail().value()) {
       this.email = Email.create(dto.email);
     }
-    if (dto.cpf != null) {
+    if (dto.cpf != null && dto.cpf != this.getCpf().value()) {
       this.cpf = Cpf.create(dto.cpf);
     }
-    if (dto.role != null) {
+    if (dto.role != null && dto.role != this.getRole().value().toString()) {
       this.role = Role.create(dto.role);
     }
-    if (dto.sector != null) {
+    if (dto.sector != null && dto.sector != this.getSector().value().toString()) {
       this.sector = CollaborationSector.create(dto.sector);
     }
-    if (dto.isActive != null) {
+    if (dto.isActive != null && dto.isActive != this.getIsActive().value()) {
       this.isActive = Logical.create(dto.isActive);
     }
   }

--- a/src/main/java/br/com/chronos/core/collaboration/domain/events/CollaboratorUpdatedEvent.java
+++ b/src/main/java/br/com/chronos/core/collaboration/domain/events/CollaboratorUpdatedEvent.java
@@ -1,0 +1,35 @@
+package br.com.chronos.core.collaboration.domain.events;
+
+import br.com.chronos.core.collaboration.domain.entities.Collaborator;
+import br.com.chronos.core.global.domain.abstracts.Event;
+import br.com.chronos.core.global.domain.records.Id;
+
+public class CollaboratorUpdatedEvent extends Event<CollaboratorUpdatedEvent.Payload> {
+  public static final String KEY = "collaboration/collaborator.updated";
+
+  public static class Payload {
+    public final String email;
+    public final String role;
+    public final String sector;
+    public final String responsibleCollaboratorId;
+    public final String collaboratorId;
+
+    public Payload(String email, String role, String sector, String collaboratorId, String responsibleCollaboratorId) {
+      this.email = email;
+      this.role = role;
+      this.sector = sector;
+      this.responsibleCollaboratorId = responsibleCollaboratorId;
+      this.collaboratorId = collaboratorId;
+    }
+  }
+
+  public CollaboratorUpdatedEvent(Collaborator collaborator, Id responsibleCollaboratorId) {
+    super(new Payload(
+        collaborator.getEmail().value(),
+        collaborator.getRole().value().toString(),
+        collaborator.getSector().value().toString(),
+        collaborator.getId().value().toString(),
+        responsibleCollaboratorId.value().toString()));
+  }
+
+}

--- a/src/main/java/br/com/chronos/core/collaboration/interfaces/CollaborationBroker.java
+++ b/src/main/java/br/com/chronos/core/collaboration/interfaces/CollaborationBroker.java
@@ -1,10 +1,13 @@
 package br.com.chronos.core.collaboration.interfaces;
 
 import br.com.chronos.core.collaboration.domain.events.CollaboratorCreatedEvent;
+import br.com.chronos.core.collaboration.domain.events.CollaboratorUpdatedEvent;
 import br.com.chronos.core.collaboration.domain.events.CollaboratorsPreparedForWorkEvent;
 
 public interface CollaborationBroker {
   public void publish(CollaboratorCreatedEvent event);
 
   public void publish(CollaboratorsPreparedForWorkEvent event);
+
+  public void publish(CollaboratorUpdatedEvent event);
 }

--- a/src/main/java/br/com/chronos/core/collaboration/use_cases/UpdateCollaboratorUseCase.java
+++ b/src/main/java/br/com/chronos/core/collaboration/use_cases/UpdateCollaboratorUseCase.java
@@ -2,9 +2,11 @@ package br.com.chronos.core.collaboration.use_cases;
 
 import br.com.chronos.core.collaboration.domain.dtos.CollaboratorDto;
 import br.com.chronos.core.collaboration.domain.entities.Collaborator;
+import br.com.chronos.core.collaboration.domain.events.CollaboratorUpdatedEvent;
 import br.com.chronos.core.collaboration.domain.exceptions.CollaboratorNotFoundException;
 import br.com.chronos.core.collaboration.domain.exceptions.ExistingCpfException;
 import br.com.chronos.core.collaboration.domain.exceptions.ExistingEmailException;
+import br.com.chronos.core.collaboration.interfaces.CollaborationBroker;
 import br.com.chronos.core.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.global.domain.records.Cpf;
 import br.com.chronos.core.global.domain.records.Email;
@@ -12,18 +14,27 @@ import br.com.chronos.core.global.domain.records.Id;
 
 public class UpdateCollaboratorUseCase {
   private final CollaboratorsRepository repository;
+  private final CollaborationBroker collaborationBroker;
 
-  public UpdateCollaboratorUseCase(CollaboratorsRepository repository) {
+  public UpdateCollaboratorUseCase(CollaboratorsRepository repository,CollaborationBroker collaborationBroker) {
+    this.collaborationBroker = collaborationBroker;
     this.repository = repository;
   }
 
-  public CollaboratorDto execute(String collaboratorId, CollaboratorDto dto, String collaborationSector) {
+  public CollaboratorDto execute(String collaboratorId, CollaboratorDto dto,String responsibleId) {
+    System.out.println("UpdateCollaboratorUseCase.execute");
+    System.out.println("collaboratorId: " + collaboratorId);
     var collaborator = findCollaborator(Id.create(collaboratorId));
-    validateUniqueEmailAndCpf(dto, Id.create(collaboratorId));
+    validateUniqueEmailAndCpf(dto,collaboratorId);
 
-    dto.setSector(collaborationSector);
     collaborator.update(dto);
+    System.out.println("collaborato sofreu update com sucesso: " + collaborator);
     repository.replace(collaborator);
+
+    System.out.println("responsibleId: " + responsibleId);
+    var event = new CollaboratorUpdatedEvent(collaborator,Id.create(responsibleId));
+    collaborationBroker.publish(event);
+
     return collaborator.getDto();
   }
 
@@ -36,23 +47,20 @@ public class UpdateCollaboratorUseCase {
     return collaborator.get();
   }
 
-  private void validateUniqueEmailAndCpf(CollaboratorDto dto, Id currentId) {
-    if (dto.email == null && dto.cpf == null)
-      return;
-
+  private void validateUniqueEmailAndCpf(CollaboratorDto dto,String currentId) {
     var existingCollaborator = repository.findByEmailOrCpf(dto.email, dto.cpf);
     Email email = dto.email != null ? Email.create(dto.email) : null;
     Cpf cpf = dto.cpf != null ? Cpf.create(dto.cpf) : null;
 
-    if (existingCollaborator.isEmpty() || existingCollaborator.get().getId().equals(currentId)) {
+    if (existingCollaborator.isEmpty() || existingCollaborator.get().getId().equals(Id.create(currentId))) {
       return;
     }
 
-    if (email != null && existingCollaborator.get().getEmail().equals(email)) {
+    if (existingCollaborator.get().getEmail().equals(email)) {
       throw new ExistingEmailException();
     }
 
-    if (cpf != null && existingCollaborator.get().getCpf().equals(cpf)) {
+    if (existingCollaborator.get().getCpf().equals(cpf)) {
       throw new ExistingCpfException();
     }
   }

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/records/fakers/DayOffScheduleFaker.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/records/fakers/DayOffScheduleFaker.java
@@ -31,7 +31,7 @@ public class DayOffScheduleFaker {
         .setWorkdaysCount(workdaysCount)
         .setDaysOffCount(daysOffCount)
         .setDaysOff(daysOff.map(dayOff -> dayOff.value()).list())
-        .setId(UUID.randomUUID().toString())
+        .setId(IdFaker.fakeDto())
         .setCollaboratorId(faker.idNumber().valid());
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/UpdateCollaboratorController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/collaboration/collaborators/UpdateCollaboratorController.java
@@ -1,13 +1,14 @@
 package br.com.chronos.server.api.controllers.collaboration.collaborators;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import br.com.chronos.core.collaboration.domain.dtos.CollaboratorDto;
+import br.com.chronos.core.collaboration.interfaces.CollaborationBroker;
 import br.com.chronos.core.collaboration.interfaces.repositories.CollaboratorsRepository;
 import br.com.chronos.core.collaboration.use_cases.UpdateCollaboratorUseCase;
 import br.com.chronos.core.global.interfaces.providers.AuthenticationProvider;
@@ -18,17 +19,19 @@ public class UpdateCollaboratorController {
   private CollaboratorsRepository repository;
   @Autowired
   private AuthenticationProvider authenticationProvider;
+  @Autowired
+  private CollaborationBroker collaborationBroker;
 
   @PutMapping("/{collaboratorId}")
   public ResponseEntity<CollaboratorDto> handle(
       @PathVariable String collaboratorId,
       @RequestBody CollaboratorDto body) {
-    var useCase = new UpdateCollaboratorUseCase(repository);
-    var account = authenticationProvider.getAccount();
+    var useCase = new UpdateCollaboratorUseCase(repository,collaborationBroker);
+    var responsibleId = authenticationProvider.getAccount().getCollaboratorId().value().toString();
     var response = useCase.execute(
         collaboratorId,
         body,
-        account.getCollaborationSector().toString());
+        responsibleId);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/br/com/chronos/server/database/jpa/collaborator/repositories/JpaCollaboratorsRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/collaborator/repositories/JpaCollaboratorsRepository.java
@@ -89,27 +89,6 @@ public class JpaCollaboratorsRepository implements CollaboratorsRepository {
         Array.createFrom(items, mapper::toEntity),
         PlusIntegerNumber.create((int) itemsCount, "contagem de colaboradores"));
   }
-
-  @Override
-  public Pair<Array<Collaborator>, PlusIntegerNumber> findManyByCollaborationSector(
-      CollaborationSector sector,
-      Logical isActive,
-      PageNumber page) {
-    var pageRequest = PageRequest.of(page.number().value() - 1, 10);
-    Page<CollaboratorModel> collaboratorModels;
-    collaboratorModels = repository.findAllByAccountRoleNotAndAccountSectorAndAccountIsActive(
-        RoleName.ADMIN,
-        sector.value(),
-        isActive.value(),
-        pageRequest);
-    var items = collaboratorModels.getContent().stream().toList();
-    var itemsCount = collaboratorModels.getTotalElements();
-
-    return new Pair<>(
-        Array.createFrom(items, mapper::toEntity),
-        PlusIntegerNumber.create((int) itemsCount, "contagem de colaboradores"));
-  }
-
   @Override
   public Optional<Collaborator> findByEmail(Email email) {
     var collaboratorModel = repository.findByAccountEmail(email.value());

--- a/src/main/java/br/com/chronos/server/queue/jobs/auth/UpdateAccountJob.java
+++ b/src/main/java/br/com/chronos/server/queue/jobs/auth/UpdateAccountJob.java
@@ -1,0 +1,23 @@
+package br.com.chronos.server.queue.jobs.auth;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import br.com.chronos.core.auth.domain.dtos.AccountDto;
+import br.com.chronos.core.auth.interfaces.repositories.AccountsRepository;
+import br.com.chronos.core.auth.use_cases.UpdateAccountUseCase;
+import br.com.chronos.core.collaboration.domain.events.CollaboratorUpdatedEvent;
+
+@Component
+public class UpdateAccountJob{
+  @Autowired
+  private AccountsRepository accountsRepository;
+  public void handle(CollaboratorUpdatedEvent.Payload payload){
+    var accountDto = new AccountDto()
+        .setEmail(payload.email)
+        .setCollaborationSector(payload.sector)
+        .setRole(payload.role)
+        .setCollaboratorId(payload.collaboratorId);
+    var useCase = new UpdateAccountUseCase(accountsRepository);
+    useCase.execute(accountDto, payload.collaboratorId);
+  }
+}

--- a/src/main/java/br/com/chronos/server/queue/rabbitmq/RabbitMqConfiguration.java
+++ b/src/main/java/br/com/chronos/server/queue/rabbitmq/RabbitMqConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 
 import br.com.chronos.core.collaboration.domain.events.CollaboratorCreatedEvent;
+import br.com.chronos.core.collaboration.domain.events.CollaboratorUpdatedEvent;
 import br.com.chronos.core.collaboration.domain.events.CollaboratorsPreparedForWorkEvent;
 import br.com.chronos.core.work_schedule.domain.events.TimePunchClosedEvent;
 
@@ -19,6 +20,10 @@ public class RabbitMqConfiguration {
   @Bean
   Queue collaboratorCreatedEventQueue() {
     return new Queue(CollaboratorCreatedEvent.KEY, true);
+  }
+  @Bean
+  Queue collaboratorUpdatedEventQueue() {
+    return new Queue(CollaboratorUpdatedEvent.KEY, true);
   }
 
   @Bean

--- a/src/main/java/br/com/chronos/server/queue/rabbitmq/brokers/RabbitMqCollaborationBroker.java
+++ b/src/main/java/br/com/chronos/server/queue/rabbitmq/brokers/RabbitMqCollaborationBroker.java
@@ -4,6 +4,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 import br.com.chronos.core.collaboration.domain.events.CollaboratorCreatedEvent;
+import br.com.chronos.core.collaboration.domain.events.CollaboratorUpdatedEvent;
 import br.com.chronos.core.collaboration.domain.events.CollaboratorsPreparedForWorkEvent;
 import br.com.chronos.core.collaboration.interfaces.CollaborationBroker;
 
@@ -23,5 +24,10 @@ public class RabbitMqCollaborationBroker implements CollaborationBroker {
   @Override
   public void publish(CollaboratorsPreparedForWorkEvent event) {
     rabbit.convertAndSend("", CollaboratorsPreparedForWorkEvent.KEY, event.getPayload());
+  }
+
+  @Override
+  public void publish(CollaboratorUpdatedEvent event) {
+    rabbit.convertAndSend("", CollaboratorUpdatedEvent.KEY, event.getPayload());
   }
 }

--- a/src/main/java/br/com/chronos/server/queue/rabbitmq/listeners/CollaborationListener.java
+++ b/src/main/java/br/com/chronos/server/queue/rabbitmq/listeners/CollaborationListener.java
@@ -6,15 +6,23 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 import br.com.chronos.core.collaboration.domain.events.CollaboratorCreatedEvent;
+import br.com.chronos.core.collaboration.domain.events.CollaboratorUpdatedEvent;
 import br.com.chronos.server.queue.jobs.auth.CreateAccountJob;
+import br.com.chronos.server.queue.jobs.auth.UpdateAccountJob;
 
 @Component
 public class CollaborationListener {
   @Autowired
   CreateAccountJob createAccountJob;
+  @Autowired
+  UpdateAccountJob updateAccountJob;
 
   @RabbitListener(queues = CollaboratorCreatedEvent.KEY)
   public void listenToCollaboratorCreated(@Payload CollaboratorCreatedEvent.Payload payload) {
     createAccountJob.handle(payload);
+  }
+  @RabbitListener(queues = CollaboratorUpdatedEvent.KEY)
+  public void listenToCollaboratorUpdated(@Payload CollaboratorUpdatedEvent.Payload payload) {
+    updateAccountJob.handle(payload);
   }
 }


### PR DESCRIPTION
## ♻️ Refactoring

### 🔀 Branch

`refactor-update-account`

### Main purpose

Create an job for updating an account when updating a collaborator to separate even further the domains

### What changed
Now when updating an collaborator it creates a job for updating its account

###  Changelog  
- **Added:** `UpdateAccountUseCase`
- **Added:** `CollaboratorUpdateEvent`
- **Added:** `UpdateAccountJob`
- **Changed: `UpdateCollaboratorUseCase`
- **Fixed: `DayOffFaker`
- **Fixed: Remove duplicate method in `JpaCollaboratorRepository`

### Checklist

- [x] Code is more maintainable
- [x] Existing functionality remains unchanged

