### PR TITLE
Verify workday absences use case

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -12,12 +12,15 @@
 
 <!-- Briefly explain what you changed to fix the issue -->
 
-###  Changelog  
+### Changelog
+
 <!-- List the changes made in this PR -->
+
 - <!-- e.g., Created new endpoint controller to create users -->
 - <!-- e.g., Updated CreateAccountUseCase -->
 
 ### How to test
+
 <!-- Tell the reviewer what to do to replicate the bug -->
 
 ### Checklist

--- a/rest-client/work-schedule/workday-logs.rest
+++ b/rest-client/work-schedule/workday-logs.rest
@@ -20,3 +20,10 @@ Authorization: Bearer {{JWT}}
 GET {{HOST}}/{{RESOURCE}}/history?date=2024-04-14&page=1&collaboratorName=tam
 Content-Type: application/json
 Authorization: Bearer {{JWT}}
+
+###
+
+## Verify workday absences
+PUT {{HOST}}/{{RESOURCE}}/absences
+Content-Type: application/json
+Authorization: Bearer {{JWT}}

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/entities/TimePunch.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/entities/TimePunch.java
@@ -30,7 +30,6 @@ public final class TimePunch extends Entity {
   }
 
   public void punch(Time time) {
-    System.out.println("isClosed(): " + isClosed());
     if (isClosed().isTrue()) {
       throw new TimePunchNotOpenException();
     }
@@ -47,7 +46,6 @@ public final class TimePunch extends Entity {
   }
 
   public void adjust(Time time, TimePunchPeriod period) {
-    System.out.println("period: " + period.name());
     switch (period.name()) {
       case TimePunchPeriod.PeriodName.FIRST_CLOCK_IN:
         firstClockIn = time;
@@ -76,6 +74,13 @@ public final class TimePunch extends Entity {
         .andNot(firstClockOut.isNull())
         .andNot(secondClockIn.isNull())
         .andNot(secondClockOut.isNull());
+  }
+
+  public Logical isEmpty() {
+    return firstClockIn.isNull()
+        .and(firstClockOut.isNull())
+        .and(secondClockIn.isNull())
+        .and(secondClockOut.isNull());
   }
 
   public Time getTotalTime() {

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/entities/WorkdayLog.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/entities/WorkdayLog.java
@@ -3,6 +3,7 @@ package br.com.chronos.core.work_schedule.domain.entities;
 import br.com.chronos.core.global.domain.abstracts.Entity;
 import br.com.chronos.core.global.domain.aggregates.ResponsibleAggregate;
 import br.com.chronos.core.global.domain.records.Date;
+import br.com.chronos.core.global.domain.records.Logical;
 import br.com.chronos.core.global.domain.records.Time;
 import br.com.chronos.core.work_schedule.domain.dtos.WorkdayLogDto;
 import br.com.chronos.core.work_schedule.domain.records.WorkdayStatus;
@@ -60,6 +61,13 @@ public final class WorkdayLog extends Entity {
     }
 
     return Time.createAsZero();
+  }
+
+  public Logical verifyAbsense() {
+    if (timePunch.isEmpty().isTrue()) {
+      status = WorkdayStatus.createAsAbsence();
+    }
+    return status.isAbsence();
   }
 
   public Date getDate() {

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/entities/WorkdayLog.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/entities/WorkdayLog.java
@@ -64,7 +64,7 @@ public final class WorkdayLog extends Entity {
   }
 
   public Logical verifyAbsense() {
-    if (timePunch.isEmpty().isTrue()) {
+    if (status.isNormalDay().and(timePunch.isEmpty()).isTrue()) {
       status = WorkdayStatus.createAsAbsence();
     }
     return status.isAbsence();

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/records/WorkdayStatus.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/records/WorkdayStatus.java
@@ -1,6 +1,7 @@
 package br.com.chronos.core.work_schedule.domain.records;
 
 import br.com.chronos.core.global.domain.exceptions.ValidationException;
+import br.com.chronos.core.global.domain.records.Logical;
 
 public record WorkdayStatus(WorkdayStatusName name) {
   public enum WorkdayStatusName {
@@ -32,12 +33,36 @@ public record WorkdayStatus(WorkdayStatusName name) {
     return new WorkdayStatus(WorkdayStatusName.DAY_OFF);
   }
 
+  public static WorkdayStatus createAsAbsence() {
+    return new WorkdayStatus(WorkdayStatusName.ABSENCE);
+  }
+
   public static WorkdayStatus createAsHoliday() {
     return new WorkdayStatus(WorkdayStatusName.HOLIDAY);
   }
 
   public static WorkdayStatus createAsWorkLeave() {
     return new WorkdayStatus(WorkdayStatusName.WORK_LEAVE);
+  }
+
+  public Logical isNormalDay() {
+    return Logical.create(name == WorkdayStatusName.NORMAL_DAY);
+  }
+
+  public Logical isAbsence() {
+    return Logical.create(name == WorkdayStatusName.ABSENCE);
+  }
+
+  public Logical isDayOff() {
+    return Logical.create(name == WorkdayStatusName.DAY_OFF);
+  }
+
+  public Logical isHoliday() {
+    return Logical.create(name == WorkdayStatusName.HOLIDAY);
+  }
+
+  public Logical isWorkLeave() {
+    return Logical.create(name == WorkdayStatusName.WORK_LEAVE);
   }
 
   public String toString() {

--- a/src/main/java/br/com/chronos/core/work_schedule/interfaces/repositories/WorkdayLogsRepository.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/interfaces/repositories/WorkdayLogsRepository.java
@@ -16,9 +16,11 @@ import br.com.chronos.core.work_schedule.domain.entities.WorkdayLog;
 import kotlin.Pair;
 
 public interface WorkdayLogsRepository {
-  Optional<WorkdayLog> findByTimePunch(Id timePunchId);
-
   Optional<WorkdayLog> findByCollaboratorAndDate(Id collaboratorId, Date date);
+
+  Array<WorkdayLog> findAllByDate(Date date);
+
+  Optional<WorkdayLog> findByTimePunch(Id timePunchId);
 
   Pair<Array<WorkdayLog>, PlusIntegerNumber> findManyByCollaboratorAndDateRange(
       Id collaboratorId,
@@ -34,6 +36,8 @@ public interface WorkdayLogsRepository {
   void add(WorkdayLog workdayLogs);
 
   void addMany(Array<WorkdayLog> workdayLogs);
+
+  void replaceMany(Array<WorkdayLog> workdayLogs);
 
   void removeManyByDate(Date date);
 

--- a/src/main/java/br/com/chronos/core/work_schedule/use_cases/VerifyWorkdayAbsencesUseCase.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/use_cases/VerifyWorkdayAbsencesUseCase.java
@@ -1,0 +1,26 @@
+package br.com.chronos.core.work_schedule.use_cases;
+
+import java.time.LocalDate;
+
+import br.com.chronos.core.global.domain.records.Date;
+import br.com.chronos.core.work_schedule.interfaces.repositories.WorkdayLogsRepository;
+
+public class VerifyWorkdayAbsencesUseCase {
+  private final WorkdayLogsRepository repository;
+
+  public VerifyWorkdayAbsencesUseCase(WorkdayLogsRepository repository) {
+    this.repository = repository;
+  }
+
+  public void execute(LocalDate date) {
+    var workdayLogs = repository.findAllByDate(Date.create(date));
+
+    workdayLogs = workdayLogs.filter(workdayLog -> {
+      var isAbsence = workdayLog.verifyAbsense();
+      return isAbsence.isTrue();
+    });
+
+    System.out.println(workdayLogs.list());
+    // repository.replaceMany(workdayLogs);
+  }
+}

--- a/src/main/java/br/com/chronos/core/work_schedule/use_cases/VerifyWorkdayAbsencesUseCase.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/use_cases/VerifyWorkdayAbsencesUseCase.java
@@ -20,7 +20,6 @@ public class VerifyWorkdayAbsencesUseCase {
       return isAbsence.isTrue();
     });
 
-    System.out.println(workdayLogs.list());
-    // repository.replaceMany(workdayLogs);
+    repository.replaceMany(workdayLogs);
   }
 }

--- a/src/main/java/br/com/chronos/server/api/controllers/work_schedule/workday_logs/VerifyWorkdayAbsencesController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/work_schedule/workday_logs/VerifyWorkdayAbsencesController.java
@@ -1,0 +1,24 @@
+package br.com.chronos.server.api.controllers.work_schedule.workday_logs;
+
+import java.time.LocalDate;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.http.ResponseEntity;
+
+import br.com.chronos.core.work_schedule.domain.dtos.WorkdayLogDto;
+import br.com.chronos.core.work_schedule.interfaces.repositories.WorkdayLogsRepository;
+import br.com.chronos.core.work_schedule.use_cases.VerifyWorkdayAbsencesUseCase;
+
+@WorkdayLogsController
+public class VerifyWorkdayAbsencesController {
+  @Autowired
+  private WorkdayLogsRepository workdayLogsRepository;
+
+  @PutMapping("/absences")
+  public ResponseEntity<WorkdayLogDto> handle() {
+    var useCase = new VerifyWorkdayAbsencesUseCase(workdayLogsRepository);
+    useCase.execute(LocalDate.now());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/br/com/chronos/server/queue/jobs/collaboration/PrepareCollaboratorsForWorkJob.java
+++ b/src/main/java/br/com/chronos/server/queue/jobs/collaboration/PrepareCollaboratorsForWorkJob.java
@@ -18,7 +18,7 @@ public class PrepareCollaboratorsForWorkJob {
   @Autowired
   private CollaborationBroker collaborationBroker;
 
-  @Scheduled(cron = "0 0 0 * * ?")
+  @Scheduled(cron = "0 5 0 * * ?")
   public void handle() {
     var useCase = new PrepareCollaboratorsForWorkUseCase(collaboratorsRepository, collaborationBroker);
     useCase.execute(LocalDate.now());

--- a/src/main/java/br/com/chronos/server/queue/jobs/work_schedule/VerifyWorkdayAbsencesJob.java
+++ b/src/main/java/br/com/chronos/server/queue/jobs/work_schedule/VerifyWorkdayAbsencesJob.java
@@ -1,0 +1,22 @@
+package br.com.chronos.server.queue.jobs.work_schedule;
+
+import java.time.LocalDate;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import br.com.chronos.core.work_schedule.interfaces.repositories.WorkdayLogsRepository;
+import br.com.chronos.core.work_schedule.use_cases.VerifyWorkdayAbsencesUseCase;
+
+@Component
+public class VerifyWorkdayAbsencesJob {
+  @Autowired
+  private WorkdayLogsRepository workdayLogsRepository;
+
+  @Scheduled(cron = "0 0 0 * * ?")
+  public void handle() {
+    var useCase = new VerifyWorkdayAbsencesUseCase(workdayLogsRepository);
+    useCase.execute(LocalDate.now());
+  }
+}

--- a/src/main/java/br/com/chronos/server/queue/jobs/work_schedule/VerifyWorkdayAbsencesJob.java
+++ b/src/main/java/br/com/chronos/server/queue/jobs/work_schedule/VerifyWorkdayAbsencesJob.java
@@ -14,7 +14,7 @@ public class VerifyWorkdayAbsencesJob {
   @Autowired
   private WorkdayLogsRepository workdayLogsRepository;
 
-  @Scheduled(cron = "0 0 0 * * ?")
+  @Scheduled(cron = "0 59 23 * * ?")
   public void handle() {
     var useCase = new VerifyWorkdayAbsencesUseCase(workdayLogsRepository);
     useCase.execute(LocalDate.now());


### PR DESCRIPTION
## 🐛 Bug Fix

### 🔀 Branch

verify-workday-absences-use-case

### Goal

Daily update the status of all normal workday logs to ABSENCE if their time punch is empty.

### How was it fixed?

By changes in the mongodb repository and use cases for hour bank transactions.

### Changelog

- Made TimePunch check if it is empty
- Made WorkdayStatus verify its own status
- Implemented findAllByDate method using JPA
- Added the use case
- Added the cron job

### How to test

<!-- Tell the reviewer what to do to replicate the bug -->

### Checklist

- [ x ] Feature is complete and working as expected  
- [ x ] Related Jira task is closed  
- [ x ] New routes added to Postman collection (if necessary)
