### PR TITLE
Get work time log use case

### DIFF
--- a/rest-client/work-schedule/workday-logs.rest
+++ b/rest-client/work-schedule/workday-logs.rest
@@ -1,6 +1,6 @@
 @RESOURCE = work-schedule/workday-logs
 @WORKDAY_LOG_ID = 94f83dca-78ec-413e-8dc5-613288d3db94
-@COLLABORATOR_Id = 94f83dca-78ec-413e-8dc5-613288d3db94
+@COLLABORATOR_Id = 9b1febb2-60e2-4369-8143-b69429bf4fb3
 
 ## Get today workday log
 GET {{HOST}}/{{RESOURCE}}/{{WORKDAY_LOG_ID}}/today
@@ -18,6 +18,13 @@ Authorization: Bearer {{JWT}}
 
 ## Get collaboration sector history
 GET {{HOST}}/{{RESOURCE}}/history?date=2024-04-14&page=1&collaboratorName=tam
+Content-Type: application/json
+Authorization: Bearer {{JWT}}
+
+###
+
+## Get work time log
+GET {{HOST}}/{{RESOURCE}}/work-time/{{COLLABORATOR_Id}}
 Content-Type: application/json
 Authorization: Bearer {{JWT}}
 

--- a/src/main/java/br/com/chronos/core/global/domain/records/DateRange.java
+++ b/src/main/java/br/com/chronos/core/global/domain/records/DateRange.java
@@ -1,6 +1,7 @@
 package br.com.chronos.core.global.domain.records;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 
 public record DateRange(Date startDate, Date endDate) {
   public static DateRange create(LocalDate startDate, LocalDate endDate) {
@@ -13,5 +14,13 @@ public record DateRange(Date startDate, Date endDate) {
     }
 
     return new DateRange(dateRangeStart, dateRangeEnd);
+  }
+
+  public static DateRange createAsCurrentMonthRange() {
+    var today = LocalDate.now();
+    var firstDayOfMonth = today.withDayOfMonth(1);
+    var currentYearMonth = YearMonth.from(today);
+    var lastDayOfMonth = currentYearMonth.atEndOfMonth();
+    return new DateRange(Date.create(firstDayOfMonth), Date.create(lastDayOfMonth));
   }
 }

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/dtos/WorkTimeLogDto.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/dtos/WorkTimeLogDto.java
@@ -1,0 +1,18 @@
+package br.com.chronos.core.work_schedule.domain.dtos;
+
+import java.time.LocalTime;
+
+public class WorkTimeLogDto {
+  public LocalTime workdayTime;
+  public LocalTime workMonthTime;
+
+  public WorkTimeLogDto setWorkdayTime(LocalTime workdayTime) {
+    this.workdayTime = workdayTime;
+    return this;
+  }
+
+  public WorkTimeLogDto setWorkMonthTime(LocalTime workMonthTime) {
+    this.workMonthTime = workMonthTime;
+    return this;
+  }
+}

--- a/src/main/java/br/com/chronos/core/work_schedule/domain/records/WorkTimeLog.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/domain/records/WorkTimeLog.java
@@ -1,0 +1,29 @@
+package br.com.chronos.core.work_schedule.domain.records;
+
+import br.com.chronos.core.global.domain.records.Array;
+import br.com.chronos.core.global.domain.records.Date;
+import br.com.chronos.core.global.domain.records.Time;
+import br.com.chronos.core.work_schedule.domain.dtos.WorkTimeLogDto;
+import br.com.chronos.core.work_schedule.domain.entities.WorkdayLog;
+
+public record WorkTimeLog(Time workdayTime, Time workMonthTime) {
+  public static WorkTimeLog create(Array<WorkdayLog> workdayLogs) {
+    var workdayTime = Time.createAsZero();
+    var workMonthTime = Time.createAsZero();
+    var today = Date.now();
+
+    for (var workdayLog : workdayLogs.list()) {
+      workMonthTime = workMonthTime.plus(workdayLog.getTimePunch().getTotalTime());
+      if (workdayLog.getDate().isEqual(today).isTrue()) {
+        workdayTime = workdayTime.plus(workdayLog.getTimePunch().getTotalTime());
+      }
+    }
+    return new WorkTimeLog(workdayTime, workMonthTime);
+  }
+
+  public WorkTimeLogDto getDto() {
+    return new WorkTimeLogDto()
+        .setWorkdayTime(workdayTime.value())
+        .setWorkMonthTime(workMonthTime.value());
+  }
+}

--- a/src/main/java/br/com/chronos/core/work_schedule/interfaces/repositories/WorkdayLogsRepository.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/interfaces/repositories/WorkdayLogsRepository.java
@@ -16,9 +16,11 @@ import br.com.chronos.core.work_schedule.domain.entities.WorkdayLog;
 import kotlin.Pair;
 
 public interface WorkdayLogsRepository {
+  Array<WorkdayLog> findAllByDate(Date date);
+
   Optional<WorkdayLog> findByCollaboratorAndDate(Id collaboratorId, Date date);
 
-  Array<WorkdayLog> findAllByDate(Date date);
+  Array<WorkdayLog> findAllByCollaboratorAndDateRange(Id collaboratorId, DateRange dateRange);
 
   Optional<WorkdayLog> findByTimePunch(Id timePunchId);
 

--- a/src/main/java/br/com/chronos/core/work_schedule/use_cases/GetWorkTimeLogUseCase.java
+++ b/src/main/java/br/com/chronos/core/work_schedule/use_cases/GetWorkTimeLogUseCase.java
@@ -1,0 +1,22 @@
+package br.com.chronos.core.work_schedule.use_cases;
+
+import br.com.chronos.core.global.domain.records.DateRange;
+import br.com.chronos.core.global.domain.records.Id;
+import br.com.chronos.core.work_schedule.domain.dtos.WorkTimeLogDto;
+import br.com.chronos.core.work_schedule.domain.records.WorkTimeLog;
+import br.com.chronos.core.work_schedule.interfaces.repositories.WorkdayLogsRepository;
+
+public class GetWorkTimeLogUseCase {
+  private final WorkdayLogsRepository repository;
+
+  public GetWorkTimeLogUseCase(WorkdayLogsRepository repository) {
+    this.repository = repository;
+  }
+
+  public WorkTimeLogDto execute(String collaboratorId) {
+    var dateRange = DateRange.createAsCurrentMonthRange();
+    var workdayLogs = repository.findAllByCollaboratorAndDateRange(Id.create(collaboratorId), dateRange);
+    var workTimeLog = WorkTimeLog.create(workdayLogs);
+    return workTimeLog.getDto();
+  }
+}

--- a/src/main/java/br/com/chronos/server/api/controllers/work_schedule/workday_logs/GetWorkTimeLogController.java
+++ b/src/main/java/br/com/chronos/server/api/controllers/work_schedule/workday_logs/GetWorkTimeLogController.java
@@ -1,0 +1,23 @@
+package br.com.chronos.server.api.controllers.work_schedule.workday_logs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import br.com.chronos.core.work_schedule.domain.dtos.WorkTimeLogDto;
+import br.com.chronos.core.work_schedule.interfaces.repositories.WorkdayLogsRepository;
+import br.com.chronos.core.work_schedule.use_cases.GetWorkTimeLogUseCase;
+
+@WorkdayLogsController
+public class GetWorkTimeLogController {
+  @Autowired
+  private WorkdayLogsRepository workdayLogsRepository;
+
+  @GetMapping("/work-time/{collaboratorId}")
+  public ResponseEntity<WorkTimeLogDto> execute(@PathVariable String collaboratorId) {
+    var useCase = new GetWorkTimeLogUseCase(workdayLogsRepository);
+    var workTimeLog = useCase.execute(collaboratorId);
+    return ResponseEntity.ok(workTimeLog);
+  }
+}

--- a/src/main/java/br/com/chronos/server/database/jpa/work_schedule/repositories/JpaWorkdayLogsRepository.java
+++ b/src/main/java/br/com/chronos/server/database/jpa/work_schedule/repositories/JpaWorkdayLogsRepository.java
@@ -50,8 +50,12 @@ interface JpaWorkdayLogsModelsRepository extends JpaRepository<WorkdayLogModel, 
       @Param("endDate") LocalDate endDate,
       PageRequest pageRequest);
 
-  Optional<WorkdayLogModel> findByCollaboratorAndDate(
-      CollaboratorModel collaborator, LocalDate Date);
+  Optional<WorkdayLogModel> findByCollaboratorAndDate(CollaboratorModel collaborator, LocalDate Date);
+
+  List<WorkdayLogModel> findAllByCollaboratorAndDateBetween(
+      CollaboratorModel collaborator,
+      LocalDate starDate,
+      LocalDate endDate);
 
   Page<WorkdayLogModel> findAllByDateAndCollaboratorNameContainingIgnoreCaseAndCollaboratorAccountSector(
       LocalDate date,
@@ -106,6 +110,17 @@ public class JpaWorkdayLogsRepository implements WorkdayLogsRepository {
       return Optional.empty();
     }
     return Optional.of(workdayLogMapper.toEntity(workdayLogModels.get()));
+  }
+
+  @Override
+  public Array<WorkdayLog> findAllByCollaboratorAndDateRange(Id collaboratorId, DateRange dateRange) {
+    var collaboratorModel = CollaboratorModel.builder().id(collaboratorId.value()).build();
+    var workdayLogModels = workdayLogsRepository.findAllByCollaboratorAndDateBetween(
+        collaboratorModel,
+        dateRange.startDate().value(),
+        dateRange.endDate().value());
+
+    return Array.createFrom(workdayLogModels, workdayLogMapper::toEntity);
   }
 
   @Override


### PR DESCRIPTION
## ✨ Feature

###  Branch  
`get-work-time-log-use-case`

###  Main Purpose  

This use case calculate the total time a collaborator worked today and in the current month.

###  Changelog  
- Added `createAsCurrentMonthRange` method in `DateRange` record.
- Added WorkTimeLog.
- Implemented `findAllByCollaboratorAndDateBetween` method using JPA for `WorkdayLogsRepository`
- Added the use case
- Added the controller
- Added rest client route for controller

###  How to Test  
- Ensure a collaborator has workday logs with filled time punch.
- Run the route for the use case using rest client.
- The status should be OK, and the work time log should be inside the response body.

###  Checklist  

- [ x ] Feature is complete and working as expected  
- [ x ] Related Jira task is closed  
- [ x ] New routes added to Rest Client (if necessary)
